### PR TITLE
Serializing object to JSON allows us to parse them

### DIFF
--- a/lib/i18n/backend/redis.rb
+++ b/lib/i18n/backend/redis.rb
@@ -3,7 +3,8 @@ require 'redis-store'
 module I18n
   module Backend
     class Redis
-      include Base, Flatten
+      include Flatten
+      include Base
       attr_accessor :store
 
       # Instantiate the store.
@@ -40,49 +41,52 @@ module I18n
         flatten_translations(locale, data, escape, false).each do |key, value|
           case value
           when Proc
-            raise "Key-value stores cannot handle procs"
+            raise 'Key-value stores cannot handle procs'
           else
-            @store.set "#{locale}.#{key}", value
+            @store.set "#{locale}.#{key}", value.to_json
           end
         end
       end
 
       def available_locales
-        locales = @store.keys.map { |k| k =~ /\./; $` }
+        locales = @store.keys.map do |k|
+          k =~ /\./
+          $`
+        end
         locales.uniq!
         locales.compact!
-        locales.map! { |k| k.to_sym }
+        locales.map!(&:to_sym)
         locales
       end
 
       protected
-        def lookup(locale, key, scope = [], options = {})
-          key = normalize_flat_keys(locale, key, scope, options[:separator])
 
-          main_key = "#{locale}.#{key}"
-          if result = @store.get(main_key)
-            return result
-          end
+      # rubocop:disable Metrics/MethodLength
+      def lookup(locale, key, scope = [], options = {})
+        key = normalize_flat_keys(locale, key, scope, options[:separator])
 
-          child_keys = @store.keys("#{main_key}.*")
-          if child_keys.empty?
-            return nil
-          end
-
-          result = { }
-          subkey_part = (main_key.size + 1)..(-1)
-          child_keys.each do |child_key|
-            subkey         = child_key[subkey_part].to_sym
-            result[subkey] = @store.get child_key
-          end
-
-          result
+        main_key = "#{locale}.#{key}"
+        if (result = @store.get(main_key))
+          return JSON.parse(result)
         end
 
-        def resolve_link(locale, key)
-          key
+        child_keys = @store.keys("#{main_key}.*")
+        return nil if child_keys.empty?
+
+        result = {}
+        subkey_part = (main_key.size + 1)..-1
+        child_keys.each do |child_key|
+          subkey         = child_key[subkey_part].to_sym
+          result[subkey] = @store.get child_key
         end
+
+        result
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def resolve_link(_locale, key)
+        key
+      end
     end
   end
 end
-


### PR DESCRIPTION
Before they were just put in as a String and we
had no other chance then `eval` those to the
corresponding object. Quite spooky and dangerous!

None of the Redis gems that we are using right now
has the ability to use other data types then
strings. So this approach is the one without the
pain and new adventures we might get in exchange
for more crowded type support at Redis side.